### PR TITLE
fix: the details header of prep is installed in a wrong dir

### DIFF
--- a/src/prep/Makefile.am.inc
+++ b/src/prep/Makefile.am.inc
@@ -13,7 +13,7 @@ include_prep_HEADERS =                              \
     %reldir%/include/semaphore.hpp                  \
     ${NOTHING}
 
-include_prep_detailsdir = ${includedir}/prep/details/include
+include_prep_detailsdir = ${includedir}/prep/include/details
 include_prep_details_HEADERS =                                      \
     %reldir%/include/details/compiler_clang.i                       \
     %reldir%/include/details/compiler_gcc.i                         \


### PR DESCRIPTION
<!-- Before creating this pull request, check the questions below: -->  

- [x] Can your code compiled successfully?  
- [x] Have you checked whether there are similar contributions in [pull requests](https://github.com/eesast/THUAI5/pulls)?  
- [x] Does your contribution conform to [CODE-OF-PRODUCT](https://github.com/Timothy-LiuXuefeng/TMChat/blob/master/CODE_OF_CONDUCT.md)?  

Discriptions of this pull request:

<!-- If you have something to say about this pull request, delete the sentence 'No additional discription.' below and add your description. -->

No additional discription.
